### PR TITLE
Ignore the venv directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ parts/
 src/mpdg.govbr.faleconosco.egg-info/
 var/
 dist/
+venv


### PR DESCRIPTION
#### Short description of what this resolves:
The CONTRIBUTING.md file states that you have to create a virtualenv called `venv`. However, it was not ignored by Git.
