### PR TITLE
Move imports to the beginning of the file in bootstrap-buildout.py

### DIFF
--- a/bootstrap-buildout.py
+++ b/bootstrap-buildout.py
@@ -22,8 +22,12 @@ import os
 import shutil
 import sys
 import tempfile
+import setuptools
+import pkg_resources
+import subprocess
 
 from optparse import OptionParser
+import zc.buildout.buildout
 
 __version__ = '2015-07-01'
 # See zc.buildout's changelog if this version is up to date.
@@ -115,8 +119,6 @@ if options.setuptools_to_dir is not None:
     setup_args['to_dir'] = options.setuptools_to_dir
 
 ez['use_setuptools'](**setup_args)
-import setuptools
-import pkg_resources
 
 # This does not (always?) update the default working set.  We will
 # do it.
@@ -187,7 +189,6 @@ if version:
     requirement = '=='.join((requirement, version))
 cmd.append(requirement)
 
-import subprocess
 if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
@@ -197,7 +198,6 @@ if subprocess.call(cmd) != 0:
 
 ws.add_entry(tmpeggs)
 ws.require(requirement)
-import zc.buildout.buildout
 
 if not [a for a in args if '=' not in a]:
     args.append('bootstrap')


### PR DESCRIPTION
#### Short description of what this resolves:
fixes some of the flake8 warnings about imports being in the wrong place
- there are still some left because there are conditional imports in boostrap.py