### PR TITLE
Remove/comment unused variables

### DIFF
--- a/src/mpdg/govbr/faleconosco/browser/faleconoscoadminview.py
+++ b/src/mpdg/govbr/faleconosco/browser/faleconoscoadminview.py
@@ -5,7 +5,7 @@ from DateTime import DateTime
 from five import grok
 from mpdg.govbr.faleconosco.browser.utilities import FaleConoscoAdminRequired
 from mpdg.govbr.faleconosco.config import DIAS_ALERTA
-from mpdg.govbr.faleconosco.config import DIAS_ATRASO
+# from mpdg.govbr.faleconosco.config import DIAS_ATRASO
 from mpdg.govbr.faleconosco.config import DIAS_PRAZO
 from mpdg.govbr.faleconosco.interfaces import IFaleConosco
 from plone import api
@@ -138,7 +138,7 @@ class FaleConoscoAdminView(FaleConoscoAdminRequired, grok.View):
         hoje = datetime.today()
         prazo = datetime.fromordinal(hoje.toordinal() - DIAS_PRAZO)
         alerta = datetime.fromordinal(prazo.toordinal() - DIAS_ALERTA)
-        atraso = datetime.fromordinal(alerta.toordinal() - DIAS_ATRASO)
+        # atraso = datetime.fromordinal(alerta.toordinal() - DIAS_ATRASO)
         data = conteudo.created.asdatetime().replace(tzinfo=None)
 
         fimalerta = prazo - timedelta(1)

--- a/src/mpdg/govbr/faleconosco/browser/mensagemaddview.py
+++ b/src/mpdg/govbr/faleconosco/browser/mensagemaddview.py
@@ -116,7 +116,7 @@ class MensagemAddView(grok.View):
             email = request.form.get('email', None)
             assunto = request.form.get('assunto', None)
             userid = request.form.get('userid', None)
-            responsavel = request.form.get('responsavel', None)
+            # responsavel = request.form.get('responsavel', None)
             id = idnormalizer.normalize(nome) + \
                 '-' + str(datetime.now().microsecond)
 
@@ -127,7 +127,6 @@ class MensagemAddView(grok.View):
 
             if acao == 'resgatar':
                 member = mtool.getAuthenticatedMember()
-                responsavel = member.getId()
                 email = member.getProperty('email')
                 assunto = fale.getAssunto()
                 fale.setResponsavel(userlogged)

--- a/src/mpdg/govbr/faleconosco/setuphandlers.py
+++ b/src/mpdg/govbr/faleconosco/setuphandlers.py
@@ -31,7 +31,7 @@ def uninstall(context):
 
 
 def create_groups(portal):
-    portal = api.portal.get()
+    api.portal.get()
     api.group.create(
         groupname='adm-fale-conosco',
         title='Administradores Fale Conosco',
@@ -52,7 +52,7 @@ def create_faq(portal):
             container=portal
         )
 
-        obj_example = api.content.create(
+        api.content.create(
             type='Document',
             title='Exemplo FAQ',
             description='Exemplo de documento do FAQ',
@@ -78,7 +78,7 @@ def create_link(portal):
     portal = api.portal.get()
     servicos = portal['servicos']
     if 'fale-conosco' not in servicos:
-        link_fale = api.content.create(
+        api.content.create(
             type='Link',
             remoteUrl='${portal_url}/fale-conosco/@@fale-conosco',
             title='Fale Conosco',
@@ -98,7 +98,7 @@ def create_textos_prontos(portal):
             description='Pasta pra armazenar textos prontos',
         )
 
-        obj_example_textos = api.content.create(
+        api.content.create(
             type='Document',
             title='Exemplo textos-prontos',
             description='Exemplo de documento de Textos Prontos',
@@ -110,20 +110,20 @@ def create_link_portal(portal):
     portal = api.portal.get()
     # obj_link= getattr(portal, 'sistema-fale-conosco' ,None )
     if 'sistema-fale-conosco' not in portal:
-        obj_link_portal = api.content.create(
+        api.content.create(
             type='Folder',
             title='Sistema Fale Conosco',
             container=portal
         )
 
-        link_painel_adm = api.content.create(
+        api.content.create(
             type='Link',
             title='Painel de Administração',
             remoteUrl='${portal_url}/@@fale-conosco-admin',
             container=portal['sistema-fale-conosco']
         )
 
-        link_cadrastro_faq = api.content.create(
+        api.content.create(
             type='Link',
             title='Cadastrar Perguntas Frequentes ',
             remoteUrl='${portal_url}/faq',

--- a/src/mpdg/govbr/faleconosco/tests/test_desarquivarmensagem_view.py
+++ b/src/mpdg/govbr/faleconosco/tests/test_desarquivarmensagem_view.py
@@ -14,7 +14,7 @@ class DesarquivarMensagemViewTest(unittest.TestCase):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
         self.view = DesarquivarMensagemView(self.portal, self.request)
-        group = api.group.create(groupname='adm-fale-conosco')
+        api.group.create(groupname='adm-fale-conosco')
 
     def test_view_desarquivar_mensagem(self):
         view = self.portal.restrictedTraverse('@@desarquivar-mensagem')

--- a/src/mpdg/govbr/faleconosco/tests/test_encaminharmsg_form.py
+++ b/src/mpdg/govbr/faleconosco/tests/test_encaminharmsg_form.py
@@ -19,7 +19,7 @@ class EncaminharMsgFormTest(unittest.TestCase):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
         alsoProvides(self.request, IFormLayer)  # suitable for testing z3c.form views
-        group = api.group.create(groupname='adm-fale-conosco')
+        api.group.create(groupname='adm-fale-conosco')
 
         self.request.form['form.widgets.uids'] = '123123132131'
         self.view = EncaminharMensagemView(self.portal, self.request)

--- a/src/mpdg/govbr/faleconosco/tests/test_faleconoscoadmin_view.py
+++ b/src/mpdg/govbr/faleconosco/tests/test_faleconoscoadmin_view.py
@@ -15,7 +15,7 @@ class FaleConoscoAdminViewTest(unittest.TestCase):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
         self.view = FaleConoscoAdminView(self.portal, self.request)
-        group = api.group.create(groupname='adm-fale-conosco')
+        api.group.create(groupname='adm-fale-conosco')
 
     def test_view_faleconosco_admin(self):
         view = self.portal.restrictedTraverse('@@fale-conosco-admin')


### PR DESCRIPTION
#### Short description of what this resolves:
Eliminate flake8 warnings about unused variables.
For some of the assignments, the right-hand-side was left because I was not sure about side-effects.
In some cases, the assignment represented some known element in a list - I only commented these as they would be not that trivial to find again if needed.