### PR TITLE
browser/fixbrokenobjects: change `FixBrokenObjects` view permission to `cmf.ManagePortal`

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@ Contributors
 ============
 
 - Samuel Carlos, samuel.moraisbsb@gmail.com
+- Bruno Barbosa, bsbruno1@gmail.com

--- a/src/mpdg/govbr/faleconosco/browser/fixbrokenobjects.py
+++ b/src/mpdg/govbr/faleconosco/browser/fixbrokenobjects.py
@@ -46,7 +46,7 @@ class FaleConoscoBaseMigrator(InplaceATFolderMigrator):
 
 class FixBrokenObjects(grok.View):
     grok.name('fixbrokenobjects')
-    grok.require('zope2.View')
+    grok.require('cmf.ManagePortal')
     grok.context(Interface)
 
     def __call__(self):

--- a/src/mpdg/govbr/faleconosco/tests/test_fixbrokenobjects_view.py
+++ b/src/mpdg/govbr/faleconosco/tests/test_fixbrokenobjects_view.py
@@ -3,6 +3,8 @@ from mpdg.govbr.faleconosco.testing import MPDG_GOVBR_FALECONOSCO_INTEGRATION_TE
 
 import unittest
 
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
+
 
 class FixBrokenObjectsViewTest(unittest.TestCase):
 
@@ -10,6 +12,8 @@ class FixBrokenObjectsViewTest(unittest.TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'Manager'])
+        login(self.portal, TEST_USER_NAME)
 
     def test_view_fixbrokenobjects(self):
         view = self.portal.restrictedTraverse('@@fixbrokenobjects')


### PR DESCRIPTION
#### Short description of what this resolves:
This PR change permission of `FixBrokenObjects` to `cmf.ManagePortal` since this only view purpose is run a content migration by admin

#### Changes proposed in this pull request:
- Update view permission

**Fixes**: #8